### PR TITLE
add high refresh support to android devices

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:mobichan/classes/arguments/board_page_arguments.dart';
 import 'package:mobichan/pages/board_page.dart';
 import 'package:mobichan/pages/boards_list_page.dart';
@@ -40,6 +43,9 @@ class App extends StatefulWidget {
 class _AppState extends State<App> {
   @override
   void initState() {
+    if (Platform.isAndroid) {
+      setOptimalDisplayMode();
+    }
     super.initState();
     if (String.fromEnvironment(ENVIRONMENT, defaultValue: GITHUB) == GITHUB) {
       Updater.checkForUpdates().then((needsUpdate) {
@@ -52,6 +58,25 @@ class _AppState extends State<App> {
         }
       });
     }
+  }
+
+  Future<void> setOptimalDisplayMode() async {
+    final List<DisplayMode> supported = await FlutterDisplayMode.supported;
+    final DisplayMode active = await FlutterDisplayMode.active;
+
+    final List<DisplayMode> sameResolution = supported
+        .where((DisplayMode m) =>
+            m.width == active.width && m.height == active.height)
+        .toList()
+          ..sort((DisplayMode a, DisplayMode b) =>
+              b.refreshRate.compareTo(a.refreshRate));
+
+    final DisplayMode mostOptimalMode =
+        sameResolution.isNotEmpty ? sameResolution.first : active;
+
+    /// This setting is per session.
+    /// Please ensure this was placed with `initState` of your root widget.
+    await FlutterDisplayMode.setPreferredMode(mostOptimalMode);
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -132,6 +132,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.2"
+  flutter_displaymode:
+    dependency: "direct main"
+    description:
+      name: flutter_displaymode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.2"
   flutter_html:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   path_provider: ^2.0.2
   flutter_vlc_player: ^6.0.2
   package_info_plus: ^1.0.3
+  flutter_displaymode: ^0.3.2
   version: ^2.0.0
   install_plugin:
     git:


### PR DESCRIPTION
Adds high refresh support to android devices. Previous version is capped to 60hz because this is what Flutter allows out of the box.